### PR TITLE
feat: Get<T> functionality (primitives only)

### DIFF
--- a/benchmarks/main.go
+++ b/benchmarks/main.go
@@ -50,7 +50,7 @@ func benchmarkisGetSingleValueByUnmarshal(b *testing.B) {
 
 func getSingleValueWithDora() string {
 	c, _ := dora.NewFromString(testJSONObject)
-	r, _ := c.GetByPath("$.item1[2].some.thing")
+	r, _ := c.Get("$.item1[2].some.thing")
 	return r
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/bradford-hamilton/dora
 
 go 1.14
+
+require github.com/spf13/cast v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/bradford-hamilton/dora
 
 go 1.14
-
-require github.com/spf13/cast v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
+github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,0 @@
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
-github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 		fmt.Printf("\nError creating client: %v\n", err)
 	}
 
-	result, err := c.GetByPath("$.item1[2].some")
+	result, err := c.Get("$.item1[2].some")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/dora/dora.go
+++ b/pkg/dora/dora.go
@@ -2,6 +2,7 @@
 package dora
 
 import (
+	"fmt"
 	"github.com/bradford-hamilton/dora/pkg/ast"
 	"github.com/bradford-hamilton/dora/pkg/lexer"
 	"github.com/bradford-hamilton/dora/pkg/parser"
@@ -45,4 +46,20 @@ func (c *Client) GetByPath(query string) (string, error) {
 		return "", err
 	}
 	return c.result, nil
+}
+
+func (c *Client) SetByPath(cursor string, val interface{}) error {
+	result, err := c.GetByPath(cursor)
+	if err != nil {
+		return fmt.Errorf("error not able to walk path provided by cursor: %w", err)
+	}
+
+	if result == val {
+		return nil
+	}
+
+	// TODO: update val
+	//c.tree.RootValue = val
+	fmt.Printf("%+v\n", c.tree)
+	return nil
 }

--- a/pkg/dora/dora_test.go
+++ b/pkg/dora/dora_test.go
@@ -75,7 +75,92 @@ func TestScanQueryTokens(t *testing.T) {
 	}
 }
 
-func TestGetByPath(t *testing.T) {
+//func TestGetByPath(t *testing.T) {
+//	testJSON := `
+//{
+//	"data": {
+//		"users": [{
+//			"first_name": "bradford",
+//			"last_name": "human",
+//			"email": "brad@example.com",
+//			"confirmed": true,
+//			"allergies": null,
+//			"age": 30,
+//			"random_items": [true, { "dog_name": "ellie" }]
+//		}]
+//	},
+//	"codes": [200, 201, 400, 403, 404],
+//	"superNest": {
+//		"inner1": {
+//			"inner2": {
+//				"inner3": {
+//					"inner4": [{ "inner5": { "inner6": "neato" } }]
+//				}
+//			}
+//		}
+//	}
+//}`
+//	tests := []struct {
+//		query          string
+//		expectedResult string
+//	}{
+//		{
+//			"$.data.users[0].first_name",
+//			"bradford",
+//		},
+//		{
+//			"$.data.users[0].confirmed",
+//			"true",
+//		},
+//		{
+//			"$.data.users[0].allergies",
+//			"null",
+//		},
+//		{
+//			"$.data.users[0].age",
+//			"30",
+//		},
+//		{
+//			"$.data.users[0].random_items",
+//			"[true, { \"dog_name\": \"ellie\" }]",
+//		},
+//		{
+//			"$.data.users[0].random_items[1]",
+//			"{ \"dog_name\": \"ellie\" }",
+//		},
+//		{
+//			"$.codes",
+//			"[200, 201, 400, 403, 404]",
+//		},
+//		{
+//			"$.codes[1]",
+//			"201",
+//		},
+//		{
+//			"$.superNest.inner1.inner2.inner3.inner4[0].inner5.inner6",
+//			"neato",
+//		},
+//	}
+//
+//	for _, tt := range tests {
+//		c, err := NewFromString(testJSON)
+//		if err != nil {
+//			t.Fatalf("\nError creating client: %v\n", err)
+//		}
+//
+//		result, err := c.GetByPath(tt.query)
+//		if err != nil {
+//			fmt.Println(err)
+//		}
+//
+//		if result != tt.expectedResult {
+//			t.Fatalf("Expected result type of %s, got: %s", tt.expectedResult, result)
+//		}
+//	}
+//}
+
+
+func TestSetByPath(t *testing.T) {
 	testJSON := `
 {
 	"data": {
@@ -105,38 +190,6 @@ func TestGetByPath(t *testing.T) {
 		expectedResult string
 	}{
 		{
-			"$.data.users[0].first_name",
-			"bradford",
-		},
-		{
-			"$.data.users[0].confirmed",
-			"true",
-		},
-		{
-			"$.data.users[0].allergies",
-			"null",
-		},
-		{
-			"$.data.users[0].age",
-			"30",
-		},
-		{
-			"$.data.users[0].random_items",
-			"[true, { \"dog_name\": \"ellie\" }]",
-		},
-		{
-			"$.data.users[0].random_items[1]",
-			"{ \"dog_name\": \"ellie\" }",
-		},
-		{
-			"$.codes",
-			"[200, 201, 400, 403, 404]",
-		},
-		{
-			"$.codes[1]",
-			"201",
-		},
-		{
 			"$.superNest.inner1.inner2.inner3.inner4[0].inner5.inner6",
 			"neato",
 		},
@@ -148,13 +201,14 @@ func TestGetByPath(t *testing.T) {
 			t.Fatalf("\nError creating client: %v\n", err)
 		}
 
-		result, err := c.GetByPath(tt.query)
+		err = c.SetByPath(tt.query, "neato")
 		if err != nil {
 			fmt.Println(err)
 		}
-
-		if result != tt.expectedResult {
-			t.Fatalf("Expected result type of %s, got: %s", tt.expectedResult, result)
-		}
+		//
+		//if result != tt.expectedResult {
+		//	t.Fatalf("Expected result type of %s, got: %s", tt.expectedResult, result)
+		//}
 	}
 }
+

--- a/pkg/dora/dora_test.go
+++ b/pkg/dora/dora_test.go
@@ -28,7 +28,9 @@ const TestJSON = `
 			}
 		}
 	},
-    "date" : "04/19/2020"
+    "date": "04/19/2020",
+    "enabled": true,
+    "PI": 3.1415
 }`
 
 func TestScanQueryTokens(t *testing.T) {
@@ -161,35 +163,83 @@ func TestGet(t *testing.T) {
 	}
 }
 
-func TestSet(t *testing.T) {
+func TestClient_GetString(t *testing.T) {
 	tests := []struct {
 		query          string
-		expectedResult interface{}
+		expectedResult string
 	}{
 		{
-			"$.date",
-			"04/20/2020",
+			query:          "$.date",
+			expectedResult: "04/19/2020",
 		},
 	}
-
 	for _, tt := range tests {
 		c, err := NewFromString(TestJSON)
 		if err != nil {
 			t.Fatalf("\nError creating client: %v\n", err)
 		}
 
-		err = c.Set(tt.query, "04/20/2020")
-		if err != nil {
-			fmt.Println(err)
-		}
-
-		result, err := c.Get(tt.query)
+		result := c.GetString(tt.query)
 		if err != nil {
 			fmt.Println(err)
 		}
 
 		if result != tt.expectedResult {
 			t.Fatalf("Expected result type of %s, got: %s", tt.expectedResult, result)
+		}
+	}
+}
+
+func TestClient_GetBool(t *testing.T) {
+	tests := []struct {
+		query          string
+		expectedResult bool
+	}{
+		{
+			query:          "$.enabled",
+			expectedResult: true,
+		},
+	}
+	for _, tt := range tests {
+		c, err := NewFromString(TestJSON)
+		if err != nil {
+			t.Fatalf("\nError creating client: %v\n", err)
+		}
+
+		result := c.GetBool(tt.query)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		if result != tt.expectedResult {
+			t.Fatalf("Expected result type of %T, got: %T", tt.expectedResult, result)
+		}
+	}
+}
+
+func TestClient_GetFloat64(t *testing.T) {
+	tests := []struct {
+		query          string
+		expectedResult float64
+	}{
+		{
+			query:          "$.PI",
+			expectedResult: 3.1415,
+		},
+	}
+	for _, tt := range tests {
+		c, err := NewFromString(TestJSON)
+		if err != nil {
+			t.Fatalf("\nError creating client: %v\n", err)
+		}
+
+		result := c.GetFloat64(tt.query)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		if result != tt.expectedResult {
+			t.Fatalf("Expected result type of %f, got: %f", tt.expectedResult, result)
 		}
 	}
 }

--- a/pkg/dora/dora_test.go
+++ b/pkg/dora/dora_test.go
@@ -5,6 +5,32 @@ import (
 	"testing"
 )
 
+const TestJSON = `
+{
+	"data": {
+		"users": [{
+			"first_name": "bradford",
+			"last_name": "human",
+			"email": "brad@example.com",
+			"confirmed": true,
+			"allergies": null,
+			"age": 30,
+			"random_items": [true, { "dog_name": "ellie" }]
+		}]
+	},
+	"codes": [200, 201, 400, 403, 404],
+	"superNest": {
+		"inner1": {
+			"inner2": {
+				"inner3": {
+					"inner4": [{ "inner5": { "inner6": "neato" } }]
+				}
+			}
+		}
+	},
+    "date" : "04/19/2020"
+}`
+
 func TestScanQueryTokens(t *testing.T) {
 	tests := []struct {
 		input         []rune
@@ -75,120 +101,43 @@ func TestScanQueryTokens(t *testing.T) {
 	}
 }
 
-//func TestGetByPath(t *testing.T) {
-//	testJSON := `
-//{
-//	"data": {
-//		"users": [{
-//			"first_name": "bradford",
-//			"last_name": "human",
-//			"email": "brad@example.com",
-//			"confirmed": true,
-//			"allergies": null,
-//			"age": 30,
-//			"random_items": [true, { "dog_name": "ellie" }]
-//		}]
-//	},
-//	"codes": [200, 201, 400, 403, 404],
-//	"superNest": {
-//		"inner1": {
-//			"inner2": {
-//				"inner3": {
-//					"inner4": [{ "inner5": { "inner6": "neato" } }]
-//				}
-//			}
-//		}
-//	}
-//}`
-//	tests := []struct {
-//		query          string
-//		expectedResult string
-//	}{
-//		{
-//			"$.data.users[0].first_name",
-//			"bradford",
-//		},
-//		{
-//			"$.data.users[0].confirmed",
-//			"true",
-//		},
-//		{
-//			"$.data.users[0].allergies",
-//			"null",
-//		},
-//		{
-//			"$.data.users[0].age",
-//			"30",
-//		},
-//		{
-//			"$.data.users[0].random_items",
-//			"[true, { \"dog_name\": \"ellie\" }]",
-//		},
-//		{
-//			"$.data.users[0].random_items[1]",
-//			"{ \"dog_name\": \"ellie\" }",
-//		},
-//		{
-//			"$.codes",
-//			"[200, 201, 400, 403, 404]",
-//		},
-//		{
-//			"$.codes[1]",
-//			"201",
-//		},
-//		{
-//			"$.superNest.inner1.inner2.inner3.inner4[0].inner5.inner6",
-//			"neato",
-//		},
-//	}
-//
-//	for _, tt := range tests {
-//		c, err := NewFromString(testJSON)
-//		if err != nil {
-//			t.Fatalf("\nError creating client: %v\n", err)
-//		}
-//
-//		result, err := c.GetByPath(tt.query)
-//		if err != nil {
-//			fmt.Println(err)
-//		}
-//
-//		if result != tt.expectedResult {
-//			t.Fatalf("Expected result type of %s, got: %s", tt.expectedResult, result)
-//		}
-//	}
-//}
-
-
-func TestSetByPath(t *testing.T) {
-	testJSON := `
-{
-	"data": {
-		"users": [{
-			"first_name": "bradford",
-			"last_name": "human",
-			"email": "brad@example.com",
-			"confirmed": true,
-			"allergies": null,
-			"age": 30,
-			"random_items": [true, { "dog_name": "ellie" }]
-		}]
-	},
-	"codes": [200, 201, 400, 403, 404],
-	"superNest": {
-		"inner1": {
-			"inner2": {
-				"inner3": {
-					"inner4": [{ "inner5": { "inner6": "neato" } }]
-				}
-			}
-		}
-	}
-}`
+func TestGet(t *testing.T) {
 	tests := []struct {
 		query          string
 		expectedResult string
 	}{
+		{
+			"$.data.users[0].first_name",
+			"bradford",
+		},
+		{
+			"$.data.users[0].confirmed",
+			"true",
+		},
+		{
+			"$.data.users[0].allergies",
+			"null",
+		},
+		{
+			"$.data.users[0].age",
+			"30",
+		},
+		{
+			"$.data.users[0].random_items",
+			"[true, { \"dog_name\": \"ellie\" }]",
+		},
+		{
+			"$.data.users[0].random_items[1]",
+			"{ \"dog_name\": \"ellie\" }",
+		},
+		{
+			"$.codes",
+			"[200, 201, 400, 403, 404]",
+		},
+		{
+			"$.codes[1]",
+			"201",
+		},
 		{
 			"$.superNest.inner1.inner2.inner3.inner4[0].inner5.inner6",
 			"neato",
@@ -196,19 +145,51 @@ func TestSetByPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		c, err := NewFromString(testJSON)
+		c, err := NewFromString(TestJSON)
 		if err != nil {
 			t.Fatalf("\nError creating client: %v\n", err)
 		}
 
-		err = c.SetByPath(tt.query, "neato")
+		result, err := c.Get(tt.query)
 		if err != nil {
 			fmt.Println(err)
 		}
-		//
-		//if result != tt.expectedResult {
-		//	t.Fatalf("Expected result type of %s, got: %s", tt.expectedResult, result)
-		//}
+
+		if result != tt.expectedResult {
+			t.Fatalf("Expected result type of %s, got: %s", tt.expectedResult, result)
+		}
 	}
 }
 
+func TestSet(t *testing.T) {
+	tests := []struct {
+		query          string
+		expectedResult interface{}
+	}{
+		{
+			"$.date",
+			"04/20/2020",
+		},
+	}
+
+	for _, tt := range tests {
+		c, err := NewFromString(TestJSON)
+		if err != nil {
+			t.Fatalf("\nError creating client: %v\n", err)
+		}
+
+		err = c.Set(tt.query, "04/20/2020")
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		result, err := c.Get(tt.query)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		if result != tt.expectedResult {
+			t.Fatalf("Expected result type of %s, got: %s", tt.expectedResult, result)
+		}
+	}
+}

--- a/pkg/dora/query.go
+++ b/pkg/dora/query.go
@@ -152,6 +152,8 @@ func (c *Client) setResultFromLiteral(value ast.Value) {
 	switch lit := value.(type) {
 	case string:
 		c.result = lit
+	case float64:
+		c.result = strconv.FormatFloat(lit, 'E', -1, 64)
 	case int:
 		c.result = strconv.Itoa(lit)
 	case bool:


### PR DESCRIPTION
### addresses #4 

change-list:
- renamed `dora.GetByPath() : string` -> `dora.Get() : string`
- added `prepAndExecQuery` combined method for prepping and executing a query
- inspired by `viper.Get<T>()`'s  implementations begins adding
  - `GetString`
  - `GetBool`
  - `GetFloat64` // needs fix - returns `0.0` from parsed query currently

### TODO

- [ ] fix `GetFloat64` call