### PR TITLE
Bugfix

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -163,10 +163,11 @@ func (l *Lexer) readString(delimiter byte) string {
 func (l *Lexer) readLine() string {
 	position := l.position
 	for {
-		l.advanceChar()
 		if l.char == 0 {
 			break
 		}
+		l.advanceChar()
+
 		if l.char == '\n' {
 			l.line++
 			l.advanceChar()

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -213,6 +213,7 @@ func (p *Parser) parseJSONArray() ast.ValueContent {
 					"Error parsing property. Expected RightBrace or Comma token, got: %s",
 					p.currentToken.Literal,
 				))
+				p.nextToken()
 			}
 		case ast.ArrayComma:
 			structure := p.parseStructure()
@@ -304,6 +305,7 @@ func (p *Parser) parseProperty() ast.Property {
 					"Error parsing property start. Expected String token, got: %s",
 					p.currentToken.Literal,
 				))
+				p.nextToken()
 			}
 		case ast.PropertyKey:
 			prop.PostKeyStructure = p.parseStructure()
@@ -316,6 +318,7 @@ func (p *Parser) parseProperty() ast.Property {
 					"Error parsing property. Expected Colon token, got: %s",
 					p.currentToken.Literal,
 				))
+				p.nextToken()
 			}
 		case ast.PropertyColon:
 			prop.PreValueStructure = p.parseStructure()


### PR DESCRIPTION
Fixing bugs mentioned in https://github.com/bradford-hamilton/dora/issues/12

1. https://github.com/bradford-hamilton/dora/blob/master/pkg/parser/parser.go#L211-L216
An Error in the input string is detected, but forgets to return, causing an infinite `for` loop.
2. https://github.com/bradford-hamilton/dora/blob/master/pkg/parser/parser.go#L302-L307
An Error in the input string is detected, but forgets to return, causing an infinite `for` loop.

3. https://github.com/bradford-hamilton/dora/blob/master/pkg/lexer/lexer.go#L166-L169
`l.char == 0` breaks the loop if `0` is found in JSON payload, but `l.advanceChar()` which was already done before that causes `l.position` to get incremented causing the slice to hit out of bound.

4. https://github.com/bradford-hamilton/dora/blob/master/pkg/parser/parser.go#L314-L319
An Error in the input string is detected, but forgets to return, causing an infinite `for` loop.